### PR TITLE
Remove dependency to DataFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ If you are new to baselines and Metacello, check out the [Baselines](https://git
 
 ## How to use it
 
+Note: This documentation will use datasets that can be found in Pharo-AI/Dataset. To load this project and reproduce those examples you can execute:
+
+```st
+Metacello new
+  baseline: 'AIDatasets';
+  repository: 'github://pharo-ai/datasets';
+  load.
+```
+
 ### DecisionTree
 
 A simple example of how to create a DecisionTree (not a decision tree model)

--- a/src/BaselineOfDecisionTreeModel/BaselineOfDecisionTreeModel.class.st
+++ b/src/BaselineOfDecisionTreeModel/BaselineOfDecisionTreeModel.class.st
@@ -5,26 +5,15 @@ Class {
 }
 
 { #category : #baselines }
-BaselineOfDecisionTreeModel >> baseline: spec [ 
+BaselineOfDecisionTreeModel >> baseline: spec [
+
 	<baseline>
-	spec for: #common do: [	
-		"External dependencies"
+	spec for: #common do: [ "Packages"
 		spec
-			baseline: 'DataFrame'
-			with: [ spec repository: 'github://PolyMathOrg/DataFrame/src' ].
-			
-		spec
-			baseline: 'AIDatasets'
-			with: [ spec repository: 'github://pharo-ai/datasets' ].
-							
-		"Packages"
-		spec
-			package: 'DecisionTree'; 
-			package: 'DecisionTree-Tests' with: [ spec requires: #('DecisionTree') ];
-			package: 'DecisionTreeModel' with: [ spec requires: #('DecisionTree') ];
-			package: 'DecisionTreeModel' with: [ spec requires: #('DataFrame') ];
-			package: 'DecisionTreeModel' with: [ spec requires: #('AIDatasets') ];
-			package: 'DecisionTreeModel-Preprocessing' with: [ spec requires: #('DecisionTreeModel') ];
-			package: 'DecisionTreeModel-Preprocessing-Tests' with: [ spec requires: #('DecisionTreeModel-Preprocessing') ];
-			package: 'DecisionTreeModel-Tests' with: [ spec requires: #('DecisionTreeModel') ]].
+			package: 'DecisionTree';
+			package: 'DecisionTree-Tests' with: [ spec requires: #( 'DecisionTree' ) ];
+			package: 'DecisionTreeModel' with: [ spec requires: #( 'DecisionTree' ) ];
+			package: 'DecisionTreeModel-Preprocessing' with: [ spec requires: #( 'DecisionTreeModel' ) ];
+			package: 'DecisionTreeModel-Preprocessing-Tests' with: [ spec requires: #( 'DecisionTreeModel-Preprocessing' ) ];
+			package: 'DecisionTreeModel-Tests' with: [ spec requires: #( 'DecisionTreeModel' ) ] ]
 ]

--- a/src/DecisionTree-Tests/ManifestDecisionTreeTests.class.st
+++ b/src/DecisionTree-Tests/ManifestDecisionTreeTests.class.st
@@ -1,0 +1,13 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestDecisionTreeTests,
+	#superclass : #PackageManifest,
+	#category : #'DecisionTree-Tests-Manifest'
+}
+
+{ #category : #'meta-data - dependency analyser' }
+ManifestDecisionTreeTests class >> manuallyResolvedDependencies [
+	^ #(#Kernel #'Collections-Abstract')
+]

--- a/src/DecisionTree/ManifestDecisionTree.class.st
+++ b/src/DecisionTree/ManifestDecisionTree.class.st
@@ -1,0 +1,13 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestDecisionTree,
+	#superclass : #PackageManifest,
+	#category : #'DecisionTree-Manifest'
+}
+
+{ #category : #'meta-data - dependency analyser' }
+ManifestDecisionTree class >> manuallyResolvedDependencies [
+	^ #(#'Collections-Streams')
+]

--- a/src/DecisionTreeModel-Preprocessing-Tests/DtmColumnDiscretizerTest.class.st
+++ b/src/DecisionTreeModel-Preprocessing-Tests/DtmColumnDiscretizerTest.class.st
@@ -6,8 +6,9 @@ Class {
 
 { #category : #tests }
 DtmColumnDiscretizerTest >> testIsFitted [
-	| aDataSeries aDiscretizer|
-	aDataSeries := DataSeries withValues: #(1 2 3 4 5 6 7).
+
+	| aDataSeries aDiscretizer |
+	aDataSeries := #( 1 2 3 4 5 6 7 ).
 	aDiscretizer := DtmColumnDiscretizer new.
 	aDiscretizer fit: aDataSeries.
 	self assert: aDiscretizer isFitted
@@ -23,28 +24,31 @@ DtmColumnDiscretizerTest >> testStep [
 
 { #category : #tests }
 DtmColumnDiscretizerTest >> testTransformReturnsADataSeries [
+
 	| aDataSeries aDiscretizer newDataSeries |
-	aDataSeries := DataSeries withValues: #(1 2 3 4 5 6 7).
+	aDataSeries := #( 1 2 3 4 5 6 7 ).
 	aDiscretizer := DtmColumnDiscretizer new.
 	aDiscretizer fit: aDataSeries.
 	newDataSeries := aDiscretizer transform: aDataSeries.
-	self assert: newDataSeries class equals: DataSeries 
+	self assert: (newDataSeries allSatisfy: [ :each | each class = DtmInterval ])
 ]
 
 { #category : #tests }
 DtmColumnDiscretizerTest >> testTransformReturnsADataSeriesWithLessUniqueValuesThanBins [
+
 	| aDataSeries aDiscretizer newDataSeries |
-	aDataSeries := DataSeries withValues: #(1 2 3 4 5 6 7).
+	aDataSeries := #( 1 2 3 4 5 6 7 ).
 	aDiscretizer := DtmColumnDiscretizer withNumberOfBins: 5.
 	aDiscretizer fit: aDataSeries.
 	newDataSeries := aDiscretizer transform: aDataSeries.
-	self assert: newDataSeries uniqueValues size <= 5
+	self assert: newDataSeries asSet size <= 5
 ]
 
 { #category : #tests }
 DtmColumnDiscretizerTest >> testTransformReturnsArrayOfIntervals [
+
 	| aDataSeries aDiscretizer discretizedDataSeries |
-	aDataSeries := DataSeries withValues: #(0 1 2 3 4 5 6 7 8 9 10).
+	aDataSeries := #( 0 1 2 3 4 5 6 7 8 9 10 ).
 	aDiscretizer := DtmColumnDiscretizer new.
 	discretizedDataSeries := aDiscretizer fitTransform: aDataSeries.
 	self assert: discretizedDataSeries anyOne class equals: DtmInterval

--- a/src/DecisionTreeModel-Preprocessing-Tests/ManifestDecisionTreeModelPreprocessingTests.class.st
+++ b/src/DecisionTreeModel-Preprocessing-Tests/ManifestDecisionTreeModelPreprocessingTests.class.st
@@ -1,0 +1,13 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestDecisionTreeModelPreprocessingTests,
+	#superclass : #PackageManifest,
+	#category : #'DecisionTreeModel-Preprocessing-Tests-Manifest'
+}
+
+{ #category : #'meta-data - dependency analyser' }
+ManifestDecisionTreeModelPreprocessingTests class >> manuallyResolvedDependencies [
+	^ #(#'Collections-Abstract')
+]

--- a/src/DecisionTreeModel-Preprocessing/DtmDiscretizer.class.st
+++ b/src/DecisionTreeModel-Preprocessing/DtmDiscretizer.class.st
@@ -21,7 +21,8 @@ DtmDiscretizer >> columnDiscretizers [
 
 { #category : #accessing }
 DtmDiscretizer >> discretizableColumnsOf: aDataset [
-	^ aDataset features select: [ :each | (aDataset featureAt: each) isNumerical ]
+
+	^ aDataset features select: [ :each | (aDataset featureAt: each) allSatisfy: #isNumber ]
 ]
 
 { #category : #'computing - fit' }

--- a/src/DecisionTreeModel-Preprocessing/ManifestDecisionTreeModelPreprocessing.class.st
+++ b/src/DecisionTreeModel-Preprocessing/ManifestDecisionTreeModelPreprocessing.class.st
@@ -1,0 +1,13 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestDecisionTreeModelPreprocessing,
+	#superclass : #PackageManifest,
+	#category : #'DecisionTreeModel-Preprocessing-Manifest'
+}
+
+{ #category : #'meta-data - dependency analyser' }
+ManifestDecisionTreeModelPreprocessing class >> manuallyResolvedDependencies [
+	^ #(#'Collections-Streams' #'Collections-Abstract' #DecisionTreeModel)
+]

--- a/src/DecisionTreeModel-Tests/DtmDatasetTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmDatasetTest.class.st
@@ -70,7 +70,8 @@ DtmDatasetTest >> testCheckIsValidTargetIsFalse [
 
 { #category : #test }
 DtmDatasetTest >> testDefaultFeaturesStartsWithAllColumns [
-	self assert: tennisDataset defaultFeatures size equals: tennisDataset dataframe numberOfColumns 
+
+	self assert: tennisDataset defaultFeatures size equals: tennisDataset datas anyOne size
 ]
 
 { #category : #'test - enumerating' }
@@ -87,7 +88,7 @@ DtmDatasetTest >> testDo [
 DtmDatasetTest >> testEntropyOf [
 	| actual expected |
 	actual := tennisDataset entropyOf: 'playTennis'.
-	expected := 0.940285958670631.
+	expected := 0.9402859586706309.
 	self assert: actual equals: expected.
 ]
 
@@ -96,7 +97,7 @@ DtmDatasetTest >> testEntropyOfTarget [
 	| actual expected |
 	tennisDataset target: #playTennis.
 	actual := tennisDataset entropyOfTarget.
-	expected := 0.940285958670631.
+	expected := 0.9402859586706309.
 	self assert: actual equals: expected.
 ]
 
@@ -145,10 +146,13 @@ DtmDatasetTest >> testFeaturesWhenInitializedFromArray [
 
 { #category : #'test - initialize' }
 DtmDatasetTest >> testFromArrayWithFeaturesWithTarget [
+
 	| arrayOfPoints newDataset |
-	arrayOfPoints := {Point x: 10 y: 10 . Point x: 5 y: 5} asArray.
-	newDataset := DtmDataset fromArray: arrayOfPoints withFeatures: #(min max) withTarget: #degrees.
-	self assert: newDataset dataframe class equals: DataFrame 
+	arrayOfPoints := {
+		                 (Point x: 10 y: 10).
+		                 (Point x: 5 y: 5) } asArray.
+	newDataset := DtmDataset fromArray: arrayOfPoints withFeatures: #( min max ) withTarget: #degrees.
+	self assert: newDataset datas equals: #( #( 10 10 45.0 ) #( 5 5 45.0 ) )
 ]
 
 { #category : #'test - initialize' }
@@ -187,10 +191,13 @@ DtmDatasetTest >> testGiniIndexWhenSelectingRows [
 
 { #category : #'test - initialize' }
 DtmDatasetTest >> testInitializeFromArray [
-	| arrayOfPoints newDataset|
-	arrayOfPoints := {Point x: 10 y: 10 . Point x: 5 y: 5} asArray.
-	newDataset := DtmDataset fromArray: arrayOfPoints withColumns: #(degrees min max).
-	self assert: newDataset dataframe class equals: DataFrame 
+
+	| arrayOfPoints newDataset |
+	arrayOfPoints := {
+		                 (Point x: 10 y: 10).
+		                 (Point x: 5 y: 5) } asArray.
+	newDataset := DtmDataset fromArray: arrayOfPoints withColumns: #( min max degrees ).
+	self assert: newDataset datas equals: #( #( 10 10 45.0 ) #( 5 5 45.0 ) )
 ]
 
 { #category : #test }
@@ -218,31 +225,6 @@ DtmDatasetTest >> testReject [
 	newDataset := DtmDataset fromArray: arrayOfPoints withColumns: #(degrees min max).
 	selectedDataset := newDataset reject: [ :each | (each at: #max) = 10].
 	self assert: selectedDataset size equals: 1
-]
-
-{ #category : #test }
-DtmDatasetTest >> testRowAt [
-	| selectedRow |
-	selectedRow := tennisDataset rowAt: 2.
-	self assert: selectedRow size equals: 1
-]
-
-{ #category : #test }
-DtmDatasetTest >> testRowAtValue [
-	| selectedRow actual expected |
-	selectedRow := tennisDataset rowAt: 2.
-	actual := (selectedRow featureAt: #outlook) asArray.
-	expected := #(sunny).
-	self assert: actual equals: expected
-]
-
-{ #category : #test }
-DtmDatasetTest >> testRowsAt [
-	| selectedRow actual expected |
-	selectedRow := tennisDataset rowsAt: #(1 1 3).
-	actual := (selectedRow featureAt: #outlook) asArray.
-	expected := #(sunny sunny cloudy).
-	self assert: actual equals: expected
 ]
 
 { #category : #'test - enumerating' }
@@ -281,14 +263,19 @@ DtmDatasetTest >> testTargetColumn [
 
 { #category : #'test - initialize' }
 DtmDatasetTest >> testWithColumnsWithFeatures [
-	| newDataset|
-	newDataset := DtmDataset withColumns: #(#(1 2 3) #(4 5 6)) withFeatures: #(feat1 feat2).
-	self assert: newDataset dataframe dimensions equals: 3@2
+
+	| newDataset |
+	newDataset := DtmDataset withColumns: #( #( 1 2 3 ) #( 4 5 6 ) ) withFeatures: #( feat1 feat2 ).
+	self assert: newDataset size equals: 3.
+	self assert: newDataset datas anyOne size equals: 2
 ]
 
 { #category : #'test - checking' }
 DtmDatasetTest >> testWithRowsWithFeatures [
-	| newDataset|
-	newDataset := DtmDataset withRows: #( #(1 2 3) #(4 5 6)) withFeatures: #(feat1 feat2 feat3).
-	self assert: newDataset dataframe dimensions equals: 2@3
+
+	| newDataset |
+	newDataset := DtmDataset withRows: #( #( 1 2 3 ) #( 4 5 6 ) ) withFeatures: #( feat1 feat2 feat3 ).
+
+	self assert: newDataset size equals: 2.
+	self assert: newDataset datas anyOne size equals: 3
 ]

--- a/src/DecisionTreeModel-Tests/DtmDatasetTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmDatasetTest.class.st
@@ -88,8 +88,8 @@ DtmDatasetTest >> testDo [
 DtmDatasetTest >> testEntropyOf [
 	| actual expected |
 	actual := tennisDataset entropyOf: 'playTennis'.
-	expected := 0.9402859586706309.
-	self assert: actual equals: expected.
+	expected := 0.940285958670631.
+	self assert: actual closeTo: expected
 ]
 
 { #category : #'test - metrics' }
@@ -97,18 +97,17 @@ DtmDatasetTest >> testEntropyOfTarget [
 	| actual expected |
 	tennisDataset target: #playTennis.
 	actual := tennisDataset entropyOfTarget.
-	expected := 0.9402859586706309.
-	self assert: actual equals: expected.
+	expected := 0.940285958670631.
+	self assert: actual closeTo: expected
 ]
 
 { #category : #'test - metrics' }
 DtmDatasetTest >> testEntropyWhenSelectingRows [
-
 	| selectedRows actual expected |
-	selectedRows := tennisDataset select: [ :row | (row at: #outlook) = #sunny ].
+	selectedRows := tennisDataset select: [ :row|(row at: #outlook) = #sunny ].
 	actual := selectedRows entropyOf: 'playTennis'.
 	expected := 0.9709505944546687.
-	self assert: actual equals: expected
+	self assert: actual closeTo: expected
 ]
 
 { #category : #test }

--- a/src/DecisionTreeModel-Tests/DtmDatasetTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmDatasetTest.class.st
@@ -102,11 +102,12 @@ DtmDatasetTest >> testEntropyOfTarget [
 
 { #category : #'test - metrics' }
 DtmDatasetTest >> testEntropyWhenSelectingRows [
-	| selectedRows actual expected |	
-	selectedRows := tennisDataset select: [ :row|(row at: #outlook) = #sunny ].
+
+	| selectedRows actual expected |
+	selectedRows := tennisDataset select: [ :row | (row at: #outlook) = #sunny ].
 	actual := selectedRows entropyOf: 'playTennis'.
 	expected := 0.9709505944546687.
-	self assert: actual equals: expected.
+	self assert: actual equals: expected
 ]
 
 { #category : #test }

--- a/src/DecisionTreeModel-Tests/DtmDecisionTreeModelTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmDecisionTreeModelTest.class.st
@@ -11,53 +11,27 @@ Class {
 
 { #category : #running }
 DtmDecisionTreeModelTest >> setUp [
-	| tennisDataFrame mixedTennisDataFrame fruitDataFrame | 
+
 	super setUp.
-	tennisDataFrame := DataFrame withRows: #(
-		(sunny high high weak false)
-  		(sunny high high strong false)
-		(cloudy high high weak true)
-		(rainy medium high weak true)
-		(rainy low normal weak true)
-		(rainy low normal strong false)
-		(cloudy low normal strong true)
-		(sunny medium high weak false)
-		(sunny low normal weak true)
-		(rainy medium normal weak true)
-		(sunny medium normal strong true)
-		(cloudy medium high strong true)
-		(cloudy high normal weak true)
-		(rainy medium high strong false)).
-	tennisDataFrame columnNames: #(outlook temperature humidity wind playTennis).
-	tennisDataset := DtmDataset fromDataFrame: tennisDataFrame.
-	
-	mixedTennisDataFrame := DataFrame withRows: #(
-		(sunny 85 85 weak false)
-  		(sunny 80 90 strong false)
-		(cloudy 83 78 weak true)
-		(rainy 70 96 weak true)
-		(rainy 68 80 weak true)
-		(rainy 65 70 strong false)
-		(cloudy 64 65 strong true)
-		(sunny 72 95 weak false)
-		(sunny 69 70 weak true)
-		(rainy 75 80 weak true)
-		(sunny 75 70 strong true)
-		(cloudy 72 90 strong true)
-		(cloudy 81 75 weak true)
-		(rainy 71 80 strong false)).
-	mixedTennisDataFrame columnNames: #(outlook temperature humidity wind playTennis).
-	mixedTennisDataset := DtmDataset fromDataFrame: mixedTennisDataFrame.
-	
-	fruitDataFrame := DataFrame withRows: #(
-		(green 3 apple)
-  		(yellow 3 apple)
-		(red 1 grape)
-		(red 1 grape)
-		(yellow 3 lemon)).
-	fruitDataFrame columnNames: #(color diameter fruit).
-	fruitDataset := DtmDataset fromDataFrame: fruitDataFrame.
-	
+	tennisDataset := DtmDataset
+		                 withRows:
+			                 #( #( sunny high high weak false ) #( sunny high high strong false ) #( cloudy high high weak true ) #( rainy medium high weak true )
+			                    #( rainy low normal weak true ) #( rainy low normal strong false ) #( cloudy low normal strong true ) #( sunny medium high weak false )
+			                    #( sunny low normal weak true ) #( rainy medium normal weak true ) #( sunny medium normal strong true )
+			                    #( cloudy medium high strong true ) #( cloudy high normal weak true ) #( rainy medium high strong false ) )
+		                 withFeatures: #( outlook temperature humidity wind playTennis ).
+
+	mixedTennisDataset := DtmDataset
+		                      withRows:
+			                      #( #( sunny 85 85 weak false ) #( sunny 80 90 strong false ) #( cloudy 83 78 weak true ) #( rainy 70 96 weak true )
+			                         #( rainy 68 80 weak true ) #( rainy 65 70 strong false ) #( cloudy 64 65 strong true ) #( sunny 72 95 weak false )
+			                         #( sunny 69 70 weak true ) #( rainy 75 80 weak true ) #( sunny 75 70 strong true ) #( cloudy 72 90 strong true )
+			                         #( cloudy 81 75 weak true ) #( rainy 71 80 strong false ) )
+		                      withFeatures: #( outlook temperature humidity wind playTennis ).
+
+	fruitDataset := DtmDataset
+		                withRows: #( #( green 3 apple ) #( yellow 3 apple ) #( red 1 grape ) #( red 1 grape ) #( yellow 3 lemon ) )
+		                withFeatures: #( color diameter fruit )
 ]
 
 { #category : #running }

--- a/src/DecisionTreeModel-Tests/DtmID3DecisionTreeModelTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmID3DecisionTreeModelTest.class.st
@@ -22,28 +22,37 @@ DtmID3DecisionTreeModelTest >> testATreeModelHasADecisionTreeAtRoot [
 
 { #category : #tests }
 DtmID3DecisionTreeModelTest >> testATreeModelIfCloudyPlayTennis [
+
 	| example |
-	example := DataSeries 
-		withKeys: #(outlook temperature humidity wind) 
-		values: #(cloudy medium high strong).
+	example := {
+		           (#outlook -> #cloudy).
+		           (#temperature -> #medium).
+		           (#humidity -> #high).
+		           (#wind -> #strong) } asDictionary.
 	self assert: (treeModel root decisionFor: example) label
 ]
 
 { #category : #tests }
 DtmID3DecisionTreeModelTest >> testATreeModelIfSunnyAndHumiditNormalPlayTennis [
+
 	| example |
-	example := DataSeries 
-		withKeys: #(outlook temperature humidity wind) 
-		values: #(sunny medium normal strong).
+	example := {
+		           (#outlook -> #sunny).
+		           (#temperature -> #medium).
+		           (#humidity -> #normal).
+		           (#wind -> #strong) } asDictionary.
 	self assert: (treeModel root decisionFor: example) label
 ]
 
 { #category : #tests }
 DtmID3DecisionTreeModelTest >> testATreeModelIfSunnyAndHumiditNormalPlayTennisWithDecisionFor [
+
 	| example |
-	example := DataSeries 
-		withKeys: #(outlook temperature humidity wind) 
-		values: #(sunny medium normal strong).
+	example := {
+		           (#outlook -> #sunny).
+		           (#temperature -> #medium).
+		           (#humidity -> #normal).
+		           (#wind -> #strong) } asDictionary.
 	self assert: (treeModel decisionFor: example) label
 ]
 
@@ -71,9 +80,12 @@ DtmID3DecisionTreeModelTest >> testFindBestSplit [
 
 { #category : #tests }
 DtmID3DecisionTreeModelTest >> testTreeModelRootDecisionForOutputsDecisionTreeNode [
-	|  example |
-	example := DataSeries 
-		withKeys: #(outlook temperature humidity wind) 
-		values: #(cloudy medium high strong).
+
+	| example |
+	example := {
+		           (#outlook -> #cloudy).
+		           (#temperature -> #medium).
+		           (#humidity -> #normal).
+		           (#wind -> #strong) } asDictionary.
 	self assert: ((treeModel root decisionFor: example) class inheritsFrom: DtmAbstractDecisionTreeNode)
 ]

--- a/src/DecisionTreeModel-Tests/DtmMultiwaySplitterTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmMultiwaySplitterTest.class.st
@@ -9,7 +9,7 @@ DtmMultiwaySplitterTest >> testSplitScoreForHumidity [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #humidity.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.15183550136234147.
+	expected := 0.15183550136234142.
 	self assert: actual equals: expected.
 ]
 
@@ -18,7 +18,7 @@ DtmMultiwaySplitterTest >> testSplitScoreForOutlook [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #outlook.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.24674981977443905.
+	expected := 0.246749819774439.
 	self assert: actual equals: expected.
 ]
 
@@ -27,7 +27,7 @@ DtmMultiwaySplitterTest >> testSplitScoreForWind [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #wind.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.0481270304082696.
+	expected := 0.04812703040826938.
 	self assert: actual equals: expected.
 ]
 
@@ -36,6 +36,6 @@ DtmMultiwaySplitterTest >> testSplitScoreForWithModel [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #humidity.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.15183550136234147.
+	expected := 0.15183550136234142.
 	self assert: actual equals: expected.
 ]

--- a/src/DecisionTreeModel-Tests/DtmMultiwaySplitterTest.class.st
+++ b/src/DecisionTreeModel-Tests/DtmMultiwaySplitterTest.class.st
@@ -9,8 +9,8 @@ DtmMultiwaySplitterTest >> testSplitScoreForHumidity [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #humidity.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.15183550136234142.
-	self assert: actual equals: expected.
+	expected := 0.15183550136234147.
+	self assert: actual closeTo: expected
 ]
 
 { #category : #tests }
@@ -18,8 +18,8 @@ DtmMultiwaySplitterTest >> testSplitScoreForOutlook [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #outlook.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.246749819774439.
-	self assert: actual equals: expected.
+	expected := 0.24674981977443905.
+	self assert: actual closeTo: expected
 ]
 
 { #category : #tests }
@@ -27,8 +27,8 @@ DtmMultiwaySplitterTest >> testSplitScoreForWind [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #wind.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.04812703040826938.
-	self assert: actual equals: expected.
+	expected := 0.0481270304082696.
+	self assert: actual closeTo: expected
 ]
 
 { #category : #tests }
@@ -36,6 +36,6 @@ DtmMultiwaySplitterTest >> testSplitScoreForWithModel [
 	| splitter actual expected|
 	splitter := DtmMultiwaySplitter forFeature: #humidity.
 	actual := splitter splitScoreFor: tennisDataset withModel: treeModel.
-	expected := 0.15183550136234142.
-	self assert: actual equals: expected.
+	expected := 0.15183550136234147.
+	self assert: actual closeTo: expected
 ]

--- a/src/DecisionTreeModel/Bag.extension.st
+++ b/src/DecisionTreeModel/Bag.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Bag }
+
+{ #category : #'*DecisionTreeModel' }
+Bag >> counts [
+	^ contents values
+]

--- a/src/DecisionTreeModel/DataFrame.extension.st
+++ b/src/DecisionTreeModel/DataFrame.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #DataFrame }
-
-{ #category : #'*DecisionTreeModel' }
-DataFrame >> asSerieOfRows [
-	"Converts DataFrame to the array of rows"
-
-	^ (1 to: self numberOfRows) collect: [ :i | self at: i ]
-]

--- a/src/DecisionTreeModel/DtmAbstractDecisionTreeModel.class.st
+++ b/src/DecisionTreeModel/DtmAbstractDecisionTreeModel.class.st
@@ -155,9 +155,10 @@ DtmAbstractDecisionTreeModel >> root: aDecisionTreeNode [
 { #category : #metrics }
 DtmAbstractDecisionTreeModel >> splitterFor: aDataset atFeature: aFeatureName [
 	"Return the corresponding splitter strategy for numerical/categorical feature"
+
 	| splitterClass |
-	splitterClass := (aDataset featureAt: aFeatureName) isNumerical 
-		ifTrue: [ self numericalSplitterClass ]
-		ifFalse: [ self categoricalSplitterClass ]. 
+	splitterClass := ((aDataset featureAt: aFeatureName) allSatisfy: #isNumber)
+		                 ifTrue: [ self numericalSplitterClass ]
+		                 ifFalse: [ self categoricalSplitterClass ].
 	^ splitterClass forFeature: aFeatureName
 ]

--- a/src/DecisionTreeModel/DtmAbstractDecisionTreeModel.class.st
+++ b/src/DecisionTreeModel/DtmAbstractDecisionTreeModel.class.st
@@ -60,7 +60,8 @@ DtmAbstractDecisionTreeModel >> decisionsForAll: aDataset [
 
 { #category : #classification }
 DtmAbstractDecisionTreeModel >> defaultDecisionFor: aDataset [
-	^ DtmDecision withLabel: aDataset targetColumn mode
+
+	^ DtmDecision withLabel: aDataset targetColumn asBag sortedCounts first value
 ]
 
 { #category : #splitting }

--- a/src/DecisionTreeModel/DtmClassifierRandomForest.class.st
+++ b/src/DecisionTreeModel/DtmClassifierRandomForest.class.st
@@ -13,9 +13,8 @@ DtmClassifierRandomForest >> treeClass [
 DtmClassifierRandomForest >> voting: anArrayOfDecisions [
 	"Specify how to mix the decisions of all the trees
 	For classification return the label with the most votes"
-	| arrayOfLabels label |
-	arrayOfLabels := anArrayOfDecisions collect: [ :each | each label].
-	label := (DataSeries withValues: arrayOfLabels) mode.
-	^ DtmDecision withLabel: label
-	
+
+	| arrayOfLabels |
+	arrayOfLabels := anArrayOfDecisions collect: [ :each | each label ].
+	^ DtmDecision withLabel: (DataSeries withValues: arrayOfLabels) asBag sortedCounts first value
 ]

--- a/src/DecisionTreeModel/DtmDataset.class.st
+++ b/src/DecisionTreeModel/DtmDataset.class.st
@@ -68,9 +68,7 @@ DtmDataset class >> fromArray: anArray withFeatures: anArrayOfSelectors withTarg
 { #category : #'instance creation' }
 DtmDataset class >> fromDataFrame: aDataFrame [
 
-	^ self new
-		  dataframe: aDataFrame;
-		  yourself
+	^ self new withRows: aDataFrame asArray withFeatures: aDataFrame columnNames
 ]
 
 { #category : #'instance creation' }
@@ -148,13 +146,6 @@ DtmDataset >> columnNames [
 { #category : #accessing }
 DtmDataset >> columnNames: anObject [
 	columnNames := anObject
-]
-
-{ #category : #accessing }
-DtmDataset >> dataframe: aDataFrame [
-
-	datas := aDataFrame asArray.
-	columnNames := aDataFrame columnNames
 ]
 
 { #category : #accessing }

--- a/src/DecisionTreeModel/DtmDataset.class.st
+++ b/src/DecisionTreeModel/DtmDataset.class.st
@@ -27,7 +27,8 @@ Class {
 	#name : #DtmDataset,
 	#superclass : #Object,
 	#instVars : [
-		'dataframe',
+		'datas',
+		'columnNames',
 		'target',
 		'features'
 	],
@@ -94,11 +95,13 @@ DtmDataset class >> withRows: anArrayOfArrays withFeatures: anArrayOfFeatureName
 DtmDataset >> allFeaturesAreEqual [
 	"Return true if all examples have the same feature values"
 
-	| arrayOfRows oneRow |
 	self size = 1 ifTrue: [ ^ true ].
-	arrayOfRows := self featuresColumns asSerieOfRows.
-	oneRow := arrayOfRows anyOne.
-	^ arrayOfRows allSatisfy: [ :each | each asDictionary = oneRow asDictionary ]
+
+	^ self features allSatisfy: [ :feature |
+		  | value featureColumn |
+		  featureColumn := self columnAt: feature.
+		  value := featureColumn anyOne.
+		  featureColumn allSatisfy: [ :each | each = value ] ]
 ]
 
 { #category : #accessing }
@@ -109,25 +112,35 @@ DtmDataset >> asArrayOfRows [
 { #category : #testing }
 DtmDataset >> checkIsFeature: aName [
 	"Check if aName is currently a feature"
+
 	^ self features includes: aName
 ]
 
 { #category : #testing }
 DtmDataset >> checkIsValidFeature: aName [
 	"Check if aName is a valid name to set as a feature"
-	^ (dataframe columnNames includes: aName) and: [ target ~= aName ]
+
+	^ (self columnNames includes: aName) and: [ target ~= aName ]
 ]
 
 { #category : #testing }
 DtmDataset >> checkIsValidTarget: aName [
 	"Check if aName is a valid name to set as a target"
-	^ (dataframe columnNames includes: aName) or: [ aName isNil ]
+
+	^ (self columnNames includes: aName) or: [ aName isNil ]
 ]
 
 { #category : #accessing }
 DtmDataset >> columnAt: aName [
-	^ dataframe column: aName
-	
+
+	| index |
+	index := self columnNames indexOf: aName.
+	^ datas collect: [ :data | data at: index ]
+]
+
+{ #category : #accessing }
+DtmDataset >> columnNames [
+	^ columnNames
 ]
 
 { #category : #accessing }
@@ -137,12 +150,20 @@ DtmDataset >> dataframe [
 
 { #category : #accessing }
 DtmDataset >> dataframe: aDataFrame [
-	dataframe := aDataFrame
+
+	datas := aDataFrame asArray.
+	columnNames := aDataFrame columnNames
+]
+
+{ #category : #accessing }
+DtmDataset >> datas [
+	^ datas
 ]
 
 { #category : #accessing }
 DtmDataset >> defaultFeatures [
-	^ dataframe columnNames reject: [ :each | each = target  ]
+
+	^ self columnNames reject: [ :each | each = target ]
 ]
 
 { #category : #enumerating }
@@ -161,8 +182,8 @@ DtmDataset >> entropyOf: aColumnName [
 	| targetColumn probabilities |
 	self isEmpty ifTrue: [ ^ 0 ].
 	targetColumn := self columnAt: aColumnName.
-	probabilities := targetColumn valueCounts / targetColumn size.
-	^ (probabilities * (probabilities log: 2)) sum negated
+	probabilities := targetColumn asBag counts / targetColumn size.
+	^ (probabilities * (probabilities collect: [ :proba | proba log: 2 ])) sum negated
 ]
 
 { #category : #metrics }
@@ -253,7 +274,7 @@ DtmDataset >> invalidTargetError: aName [
 
 { #category : #testing }
 DtmDataset >> isEmpty [
-	^ dataframe isEmpty 
+	^ self datas isEmpty 
 ]
 
 { #category : #accessing }
@@ -263,8 +284,9 @@ DtmDataset >> numberOfSplits [
 ]
 
 { #category : #accessing }
-DtmDataset >> possibleValuesForFeatureAt: aFeatureName [ 
-	^ (self featureAt: aFeatureName) uniqueValues 
+DtmDataset >> possibleValuesForFeatureAt: aFeatureName [
+
+	^ (self featureAt: aFeatureName) asSet
 ]
 
 { #category : #enumerating }
@@ -314,7 +336,8 @@ DtmDataset >> select: aBlock [
 
 { #category : #accessing }
 DtmDataset >> size [
-	^ dataframe size
+
+	^ self datas size
 ]
 
 { #category : #enumerating }
@@ -353,5 +376,6 @@ DtmDataset >> targetColumn [
 
 { #category : #testing }
 DtmDataset >> targetHasOneLabel [
-	^ self targetColumn uniqueValues size = 1
+
+	^ self targetColumn asSet size = 1
 ]

--- a/src/DecisionTreeModel/DtmDataset.class.st
+++ b/src/DecisionTreeModel/DtmDataset.class.st
@@ -36,11 +36,6 @@ Class {
 }
 
 { #category : #'instance creation' }
-DtmDataset class >> defaultDataFrameClass [
-	^ DataFrame 
-]
-
-{ #category : #'instance creation' }
 DtmDataset class >> defaultFeaturesFor: anObject [
 	^ anObject allUnarySelectors
 ]
@@ -54,10 +49,8 @@ DtmDataset class >> fromArray: anArray [
 DtmDataset class >> fromArray: anArray withColumns: anArrayOfSelectors [
 	"Creates a DtmDataset each row is an element from anArray and each features is
 	a selector from anArrayOfSelectors evaluated on the object"
-	| valuesForDataFrame newDataFrame|
-	valuesForDataFrame := anArray collect: [:each | anArrayOfSelectors collect: [ :selector | each perform: selector ] ].
-	newDataFrame := self defaultDataFrameClass withRows: valuesForDataFrame columnNames: anArrayOfSelectors.
-	^ self new dataframe: newDataFrame; yourself
+
+	^ self withRows: (anArray collect: [ :each | anArrayOfSelectors collect: [ :selector | each perform: selector ] ]) withFeatures: anArrayOfSelectors
 ]
 
 { #category : #'instance creation' }
@@ -82,16 +75,21 @@ DtmDataset class >> fromDataFrame: aDataFrame [
 
 { #category : #'instance creation' }
 DtmDataset class >> withColumns: anArrayOfArrays withFeatures: anArrayOfFeatureNames [
-	| newDataFrame |
-	newDataFrame := self defaultDataFrameClass withColumns: anArrayOfArrays columnNames: anArrayOfFeatureNames.
-	^ self new dataframe: newDataFrame; yourself
+
+	| rows |
+	rows := Array new: anArrayOfArrays anyOne size.
+	1 to: rows size do: [ :index | rows at: index put: (Array new: anArrayOfArrays size) ].
+	anArrayOfArrays doWithIndex: [ :array :colIndex | array doWithIndex: [ :elem :rowIndex | (rows at: rowIndex) at: colIndex put: elem ] ].
+	^ self withRows: rows withFeatures: anArrayOfFeatureNames
 ]
 
 { #category : #'instance creation' }
 DtmDataset class >> withRows: anArrayOfArrays withFeatures: anArrayOfFeatureNames [
-	| newDataFrame |
-	newDataFrame := self defaultDataFrameClass withRows: anArrayOfArrays columnNames: anArrayOfFeatureNames.
-	^ self new dataframe: newDataFrame; yourself
+
+	^ self new
+		  datas: anArrayOfArrays;
+		  columnNames: anArrayOfFeatureNames;
+		  yourself
 ]
 
 { #category : #testing }
@@ -148,6 +146,11 @@ DtmDataset >> columnNames [
 ]
 
 { #category : #accessing }
+DtmDataset >> columnNames: anObject [
+	columnNames := anObject
+]
+
+{ #category : #accessing }
 DtmDataset >> dataframe: aDataFrame [
 
 	datas := aDataFrame asArray.
@@ -157,6 +160,12 @@ DtmDataset >> dataframe: aDataFrame [
 { #category : #accessing }
 DtmDataset >> datas [
 	^ datas
+]
+
+{ #category : #accessing }
+DtmDataset >> datas: anObject [
+
+	datas := anObject deepCopy
 ]
 
 { #category : #accessing }
@@ -207,9 +216,9 @@ DtmDataset >> featureAt: aName ifAbsent: aBlock [
 { #category : #accessing }
 DtmDataset >> featureAt: aName put: anArray [
 
-	| index |
-	index := self columnNames indexOf: aName.
-	self datas with: anArray do: [ :each :replacement | each at: index put: replacement ]
+	| col |
+	col := self columnNames indexOf: aName.
+	anArray doWithIndex: [ :replacement :row | (self datas at: row) at: col put: replacement ]
 ]
 
 { #category : #testing }

--- a/src/DecisionTreeModel/DtmDataset.class.st
+++ b/src/DecisionTreeModel/DtmDataset.class.st
@@ -74,7 +74,10 @@ DtmDataset class >> fromArray: anArray withFeatures: anArrayOfSelectors withTarg
 
 { #category : #'instance creation' }
 DtmDataset class >> fromDataFrame: aDataFrame [
-	^ self new dataframe: aDataFrame; yourself 
+
+	^ self new
+		  dataframe: aDataFrame;
+		  yourself
 ]
 
 { #category : #'instance creation' }
@@ -168,7 +171,8 @@ DtmDataset >> defaultFeatures [
 
 { #category : #enumerating }
 DtmDataset >> do: aBlock [
-	self dataframe do: aBlock 
+
+	self datas do: [ :data | aBlock value: (Dictionary newFromKeys: self columnNames andValues: data) ]
 ]
 
 { #category : #testing }
@@ -212,7 +216,8 @@ DtmDataset >> featureAt: aName put: anAray [
 
 { #category : #testing }
 DtmDataset >> featureHasOneValue: featureName [
-	^ (self featureAt: featureName) uniqueValues size = 1 
+
+	^ (self featureAt: featureName) asSet size = 1
 ]
 
 { #category : #exceptions }
@@ -293,8 +298,8 @@ DtmDataset >> possibleValuesForFeatureAt: aFeatureName [
 DtmDataset >> reject: aBlock [
 
 	| selectedRows |
-	selectedRows := self dataframe reject: aBlock.
-	^ (self class fromDataFrame: selectedRows)
+	selectedRows := self datas reject: [ :data | aBlock value: (Dictionary newFromKeys: self columnNames andValues: data) ].
+	^ (self class withRows: selectedRows withFeatures: self columnNames)
 		  target: target;
 		  features: self features;
 		  yourself
@@ -326,12 +331,13 @@ DtmDataset >> rowsAt: anArrayOfNumbers [
 
 { #category : #enumerating }
 DtmDataset >> select: aBlock [
+
 	| selectedRows |
-	selectedRows := self dataframe select: aBlock.
-	^ (self class fromDataFrame: selectedRows)
-		target: target; 
-		features: self features;
-		yourself
+	selectedRows := self datas select: [ :data | aBlock value: (Dictionary newFromKeys: self columnNames andValues: data) ].
+	^ (self class withRows: selectedRows withFeatures: self columnNames)
+		  target: target;
+		  features: self features;
+		  yourself
 ]
 
 { #category : #accessing }
@@ -342,13 +348,14 @@ DtmDataset >> size [
 
 { #category : #enumerating }
 DtmDataset >> split: aBlock [
+
 	| selectedRows |
-	selectedRows := self dataframe select: aBlock.
-	^ (self splitClass fromDataFrame: selectedRows)
-		target: target;
-		features: self features;
-		parent: self;
-		yourself
+	selectedRows := self datas select: [ :data | aBlock value: (Dictionary newFromKeys: self columnNames andValues: data) ].
+	^ (self splitClass withRows: selectedRows withFeatures: self columnNames)
+		  target: target;
+		  features: self features;
+		  parent: self;
+		  yourself
 ]
 
 { #category : #accessing }

--- a/src/DecisionTreeModel/DtmDataset.class.st
+++ b/src/DecisionTreeModel/DtmDataset.class.st
@@ -109,7 +109,8 @@ DtmDataset >> allFeaturesAreEqual [
 
 { #category : #accessing }
 DtmDataset >> asArrayOfRows [
-	^ dataframe asSerieOfRows
+
+	^ self datas collect: [ :data | Dictionary newFromKeys: self columnNames andValues: data ]
 ]
 
 { #category : #testing }
@@ -144,11 +145,6 @@ DtmDataset >> columnAt: aName [
 { #category : #accessing }
 DtmDataset >> columnNames [
 	^ columnNames
-]
-
-{ #category : #accessing }
-DtmDataset >> dataframe [
-	^ dataframe
 ]
 
 { #category : #accessing }
@@ -209,9 +205,11 @@ DtmDataset >> featureAt: aName ifAbsent: aBlock [
 ]
 
 { #category : #accessing }
-DtmDataset >> featureAt: aName put: anAray [
-	^ self dataframe column: aName put: anAray 
-	
+DtmDataset >> featureAt: aName put: anArray [
+
+	| index |
+	index := self columnNames indexOf: aName.
+	self datas with: anArray do: [ :each :replacement | each at: index put: replacement ]
 ]
 
 { #category : #testing }
@@ -239,19 +237,13 @@ DtmDataset >> features: aCollection [
 		ifNone: [ features := aCollection  ]
 ]
 
-{ #category : #accessing }
-DtmDataset >> featuresColumns [
-
-	^ dataframe columns: self features
-]
-
 { #category : #metrics }
 DtmDataset >> giniIndexOf: aColumnName [
 
 	| targetColumn probabilities |
 	self isEmpty ifTrue: [ ^ 0 ].
 	targetColumn := self columnAt: aColumnName.
-	probabilities := targetColumn valueCounts / targetColumn size.
+	probabilities := targetColumn asBag counts / targetColumn size.
 	^ 1 - probabilities squared sum
 ]
 
@@ -262,7 +254,8 @@ DtmDataset >> giniIndexOfTarget [
 
 { #category : #testing }
 DtmDataset >> ifEmpty: emptyBlock ifNotEmpty: notEmptyBlock [
-	^ dataframe ifEmpty: emptyBlock ifNotEmpty: notEmptyBlock
+
+	^ self datas ifEmpty: emptyBlock ifNotEmpty: notEmptyBlock
 ]
 
 { #category : #exceptions }
@@ -308,25 +301,6 @@ DtmDataset >> reject: aBlock [
 { #category : #testing }
 DtmDataset >> resetFeatures [
 	features := nil
-]
-
-{ #category : #accessing }
-DtmDataset >> rowAt: aNumber [
-	^ self rowsAt: { aNumber } asArray
-]
-
-{ #category : #accessing }
-DtmDataset >> rowsAt: anArrayOfNumbers [
-	"Selection of rows by number. Allows for repited indexes."
-	| selectedRows |
-	selectedRows := DataFrame withColumnNames: self dataframe columnNames.
-	1 to: anArrayOfNumbers size do: [ :each |
-		 selectedRows addRow: (self dataframe rowAt: each)
-	].
-	^ (self class fromDataFrame: selectedRows)
-		target: target;
-		features: self features;
-		yourself
 ]
 
 { #category : #enumerating }

--- a/src/DecisionTreeModel/DtmOneVsAllSplitter.class.st
+++ b/src/DecisionTreeModel/DtmOneVsAllSplitter.class.st
@@ -46,11 +46,11 @@ DtmOneVsAllSplitter >> printOn: aStream [
 { #category : #metrics }
 DtmOneVsAllSplitter >> setBestLevelFor: aDataset withModel: aDecisionTreeModel [
 	"Compares one level to the rest of the values, and set the best the as the level of the splitter"
-	| scoresDict  |
-	scoresDict := (aDataset featureAt: feature) uniqueValues collect: [ :value | 
-		level := value.
-		value -> (aDecisionTreeModel gainMeasureOf: aDataset given: self). "Get score of setting the level to the current value"
-	].
+
+	| scoresDict |
+	scoresDict := (aDataset featureAt: feature) asSet collect: [ :value |
+		              level := value.
+		              value -> (aDecisionTreeModel gainMeasureOf: aDataset given: self) "Get score of setting the level to the current value" ].
 	scoresDict := scoresDict asDictionary.
 	level := scoresDict keyAtIdentityValue: scoresDict max "Set best level"
 ]

--- a/src/DecisionTreeModel/DtmThresholdSplitter.class.st
+++ b/src/DecisionTreeModel/DtmThresholdSplitter.class.st
@@ -36,11 +36,11 @@ DtmThresholdSplitter >> printOn: aStream [
 { #category : #metrics }
 DtmThresholdSplitter >> setBestThresholdFor: aDataset withModel: aDecisionTreeModel [
 	"Applies a threshold over the data, and set the best the as the threshold of the splitter"
-	| scoresDict  |
-	scoresDict := (aDataset featureAt: feature) uniqueValues sorted allButLast collect: [ :value | 
-		threshold := value.
-		value -> (aDecisionTreeModel gainMeasureOf: aDataset given: self). "Get score of setting the threshold to the current value"
-	].
+
+	| scoresDict |
+	scoresDict := (aDataset featureAt: feature) asSet sorted allButLast collect: [ :value |
+		              threshold := value.
+		              value -> (aDecisionTreeModel gainMeasureOf: aDataset given: self) "Get score of setting the threshold to the current value" ].
 	scoresDict := scoresDict asDictionary.
 	threshold := scoresDict keyAtIdentityValue: scoresDict max "Set best threshold"
 ]

--- a/src/DecisionTreeModel/ManifestDecisionTreeModel.class.st
+++ b/src/DecisionTreeModel/ManifestDecisionTreeModel.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'DecisionTreeModel-Manifest'
 }
 
+{ #category : #'meta-data - dependency analyser' }
+ManifestDecisionTreeModel class >> manuallyResolvedDependencies [
+	^ #(#'Collections-Streams' #'Math-Operations-Extensions')
+]
+
 { #category : #'code-critics' }
 ManifestDecisionTreeModel class >> ruleReNotOptimizedIfRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#DtmDataset #featureAt:ifAbsent: #false)) #'2023-02-03T15:24:44.672+01:00') )


### PR DESCRIPTION
This PR replace the use of a DataFrame as a base structure by the use of an array of values and an array of column names. 

Fixes #6 